### PR TITLE
Rename sacfile to SacFile.

### DIFF
--- a/pysmo/sac/sacfunc.py
+++ b/pysmo/sac/sacfunc.py
@@ -35,7 +35,7 @@ Copyright (c) 2012 Simon Lloyd
 
 def sac2xy(sacobj, retarray=False):
     """
-    Return time and amplitude from a sacfile.
+    Return time and amplitude from a SacFile.
 
     Default is to return a python list. With
     kwarg retarray=True a numpy array is returned
@@ -43,7 +43,7 @@ def sac2xy(sacobj, retarray=False):
     Example:
     >>> import pysmo.sac.sacio as sacio
     >>> import pysmo.sac.sacfunc as sacfunc
-    >>> sacobj = sacio.sacfile('file.sac')
+    >>> sacobj = sacio.SacFile('file.sac')
     >>> time, vals = sacfunc.sac2xy(sacobj, retarray=True)
     """
     import numpy as np
@@ -64,7 +64,7 @@ def plotsac(sacobj, outfile=None, showfig=True):
     Example:
     >>> import pysmo.sac.sacio as sacio
     >>> import pysmo.sac.sacfunc as sacfunc
-    >>> sacobj = sacio.sacfile('file.sac')
+    >>> sacobj = sacio.SacFile('file.sac')
     >>> sacfunc.plotsac(sacobj)
     """
     import matplotlib.pyplot as plt
@@ -83,7 +83,7 @@ def resample(sacobj, delta_new):
     Example:
     >>> import pysmo.sac.sacio as sacio
     >>> import pysmo.sac.sacfunc as sacfunc
-    >>> sacobj = sacio.sacfile('file.sac', 'rw')
+    >>> sacobj = sacio.SacFile('file.sac', 'rw')
     >>> delta_old = sacobj.delta
     >>> delta_new = delta_old * 2
     >>> data_new = sacfunc.resample(sac, delta_new)
@@ -103,7 +103,7 @@ def detrend(sacobj):
     Example:
     >>> import pysmo.sac.sacio as sacio
     >>> import pysmo.sac.sacfunc as sacfunc
-    >>> sacobj = sacio.sacfile('file.sac', 'rw')
+    >>> sacobj = sacio.SacFile('file.sac', 'rw')
     >>> detrended_data = sacfunc.detrend(sacobj)
     """
     import scipy.signal
@@ -111,7 +111,7 @@ def detrend(sacobj):
 
 def calc_az(sacobj, ellps='WGS84'):
     """
-    Return azimuth (in DEG) from sacfile. The default
+    Return azimuth (in DEG) from SacFile. The default
     ellipse used is 'WGS84', but others may be specified. For
     more information see:
 
@@ -121,7 +121,7 @@ def calc_az(sacobj, ellps='WGS84'):
     Example:
     >>> import pysmo.sac.sacio as sacio
     >>> import pysmo.sac.sacfunc as sacfunc
-    >>> sacobj = sacio.sacfile('file.sac')
+    >>> sacobj = sacio.SacFile('file.sac')
     >>> azimuth = sacfunc.calc_az(sacobj) # Use default WGS84.
     >>> azimuth = sacfunc.calc_az(sacobj, ellps='clrk66') # Use Clarke 1966 ellipsoid.
     """
@@ -129,7 +129,7 @@ def calc_az(sacobj, ellps='WGS84'):
 
 def calc_baz(sacobj, ellps='WGS84'):
     """
-    Return backazimuth (in DEG) from sacfile. The default
+    Return backazimuth (in DEG) from SacFile. The default
     ellipse used is 'WGS84', but others may be specified. For
     more information see:
 
@@ -139,7 +139,7 @@ def calc_baz(sacobj, ellps='WGS84'):
     Example:
     >>> import pysmo.sac.sacio as sacio
     >>> import pysmo.sac.sacfunc as sacfunc
-    >>> sacobj = sacio.sacfile('file.sac')
+    >>> sacobj = sacio.SacFile('file.sac')
     >>> backazimuth = sacfunc.calc_baz(sacobj) # Use default WGS84.
     >>> backazimuth = sacfunc.calc_baz(sacobj, ellps='clrk66') # Use Clarke 1966 ellipsoid.
     """
@@ -147,7 +147,7 @@ def calc_baz(sacobj, ellps='WGS84'):
 
 def calc_dist(sacobj, ellps='WGS84'):
     """
-    Return great circle distance (in km) from sacfile. The default
+    Return great circle distance (in km) from SacFile. The default
     ellipse used is 'WGS84', but others may be specified. For
     more information see:
 
@@ -157,7 +157,7 @@ def calc_dist(sacobj, ellps='WGS84'):
     Example:
     >>> import pysmo.sac.sacio as sacio
     >>> import pysmo.sac.sacfunc as sacfunc
-    >>> sacobj = pysmo.sac.sacio.sacfile('file.sac')
+    >>> sacobj = pysmo.sac.sacio.SacFile('file.sac')
     >>> distance = sacfunc.calc_dist(sacobj) # Use default WGS84.
     >>> distance = sacfunc.calc_dist(sacobj, ellps='clrk66') # Use Clarke 1966 ellipsoid.
     """
@@ -187,7 +187,7 @@ def envelope(sacobj, Tn, alpha):
     Example:
     >>> import pysmo.sac.sacio as sacio
     >>> import pysmo.sac.sacfunc as sacfunc
-    >>> sacobj = sacio.sacfile('file.sac')
+    >>> sacobj = sacio.SacFile('file.sac')
     >>> Tn = 50 # Center Gaussian filter at 50s period
     >>> alpha = 50 # Set alpha (which determines filterwidth) to 50
     >>> envelope = sacfunc.envelope(sacobj, Tn, alpha)
@@ -200,7 +200,7 @@ def gauss(sacobj, Tn, alpha):
     Example:
     >>> import pysmo.sac.sacio as sacio
     >>> import pysmo.sac.sacfunc as sacfunc
-    >>> sacobj = sacio.sacfile('file.sac')
+    >>> sacobj = sacio.SacFile('file.sac')
     >>> Tn = 50 # Center Gaussian filter at 50s period
     >>> alpha = 50 # Set alpha (which determines filterwidth) to 50
     >>> data = sacfunc.gauss(sacobj, Tn, alpha)

--- a/pysmo/sac/sacio.py
+++ b/pysmo/sac/sacio.py
@@ -30,14 +30,14 @@ Copyright (c) 2012 Simon Lloyd
 """
 
 
-class sacfile(object):
+class SacFile(object):
     """
     Python class for accessing SAC files. Set or read headerfields
     or data.
 
     Example:
-    >>> from pysmo.sac.sacio import sacfile
-    >>> sacobj = sacfile('file.sac', 'rw')
+    >>> from pysmo.sac.sacio import SacFile
+    >>> sacobj = SacFile('file.sac', 'rw')
     >>> print sacobj.delta
     0.5
     >>> sacobj.delta = 2
@@ -334,3 +334,6 @@ class sacfile(object):
         self.depmin = min(self.data)
         self.depmax = max(self.data)
         self.depmen = sum(self.data)/self.npts
+
+# Set this for compatibility
+sacfile = SacFile

--- a/pysmo/sac/sacmeth.py
+++ b/pysmo/sac/sacmeth.py
@@ -18,12 +18,12 @@
 __copyright__ = """
 Copyright (c) 2012 Simon Lloyd
 """
-from sacio import sacfile
+from sacio import SacFile
 import sacfunc as sf
 
-class sacfile_extended(sacfile):
+class SacFileExt(SacFile):
     """
-    Inherited class to do more then basic IO on a sacfile object.
+    Inherited class to do more then basic IO on a SacFile object.
     Basically this is to provide an alternative way of using the
     funtions in sacfunc.py
     """
@@ -55,3 +55,6 @@ class sacfile_extended(sacfile):
             self.dist = sf.calc_dist(self, ellps)
         except:
             pass
+
+# This is for compatibility
+sacfile_extended = SacFileExt

--- a/tests/test_sacfunc.py
+++ b/tests/test_sacfunc.py
@@ -30,28 +30,28 @@ def testfile():
 
 @pytest.fixture()
 def ro_sacobj(tmpdir, testfile):
-    """Return read-only sacfile object"""
+    """Return read-only SacFile object"""
     ro_file = os.path.join(tmpdir, 'readonly.sac')
     shutil.copyfile(testfile, ro_file)
-    return sacio.sacfile(ro_file)
+    return sacio.SacFile(ro_file)
 
 @pytest.fixture()
 def rw_sacobj(tmpdir, testfile):
-    """Return read-write sacfile object"""
+    """Return read-write SacFile object"""
     rw_file = os.path.join(tmpdir, 'readwrite.sac')
     shutil.copyfile(testfile, rw_file)
-    return sacio.sacfile(rw_file, 'rw')
+    return sacio.SacFile(rw_file, 'rw')
 
 @pytest.fixture()
 def new_sacobj(tmpdir, testfile):
-    """Return new sacfile object"""
+    """Return new SacFile object"""
     new_file = os.path.join(tmpdir, 'new.sac')
     shutil.copyfile(testfile, new_file)
-    return sacio.sacfile(new_file, 'new')
+    return sacio.SacFile(new_file, 'new')
 
 def test_sac2xy_list(ro_sacobj):
     """
-    Get time and data as lists from sacfile object
+    Get time and data as lists from SacFile object
     and verify their contents.
     """
     time, vals = sacfunc.sac2xy(ro_sacobj)
@@ -62,7 +62,7 @@ def test_sac2xy_list(ro_sacobj):
 
 def test_sac2xy_array(ro_sacobj):
     """
-    Get time and data as numpy arrays from sacfile
+    Get time and data as numpy arrays from SacFile
     object and verify their contents.
     """
     time, vals = sacfunc.sac2xy(ro_sacobj, retarray=True)
@@ -82,21 +82,21 @@ def test_plotsac(ro_sacobj):
     return fig
 
 def test_resample(ro_sacobj):
-    """Resample sacfile object and verify resampled data."""
+    """Resample SacFile object and verify resampled data."""
     delta_old = ro_sacobj.delta
     delta_new = delta_old * 2
     data_new = sacfunc.resample(ro_sacobj, delta_new)
     assert pytest.approx(data_new[6]) == -1558.4662660
 
 def test_detrend(ro_sacobj):
-    """Detrend sacfile object and verify mean is 0."""
+    """Detrend SacFile object and verify mean is 0."""
     detrended_data = sacfunc.detrend(ro_sacobj)
     assert np.mean(ro_sacobj.data) != 0
     assert pytest.approx(np.mean(detrended_data)) == 0
 
 def test_calcaz(ro_sacobj):
     """
-    Calculate azimuth from sacfile object and verify
+    Calculate azimuth from SacFile object and verify
     the calculated values. The reference values were
     obtained from previous runs of this function and
     verified against values obtained using the 'sac'
@@ -109,7 +109,7 @@ def test_calcaz(ro_sacobj):
 
 def test_calcbaz(ro_sacobj):
     """
-    Calculate back azimuth from sacfile object and verify
+    Calculate back azimuth from SacFile object and verify
     the calculated values. The reference values were
     obtained from previous runs of this function and
     verified against values obtained using the 'sac'
@@ -122,7 +122,7 @@ def test_calcbaz(ro_sacobj):
 
 def test_calcdist(ro_sacobj):
     """
-    Calculate distance from sacfile object and verify
+    Calculate distance from SacFile object and verify
     the calculated values. The reference values were
     obtained from previous runs of this function and
     verified against values obtained using the 'sac'
@@ -135,7 +135,7 @@ def test_calcdist(ro_sacobj):
 
 def test_envelope(ro_sacobj):
     """
-    Calculate gaussian envelope from sacfile object and verify
+    Calculate gaussian envelope from SacFile object and verify
     the calculated values. The reference values were
     obtained from previous runs of this function.
     """
@@ -146,7 +146,7 @@ def test_envelope(ro_sacobj):
 
 def test_gauss(ro_sacobj):
     """
-    Calculate gaussian filtered data from sacfile object and
+    Calculate gaussian filtered data from SacFile object and
     verify the calculated values. The reference values were
     obtained from previous runs of this function.
     """

--- a/tests/test_sacio.py
+++ b/tests/test_sacio.py
@@ -17,9 +17,9 @@ class sacioTestCase(unittest.TestCase):
         new_file = os.path.join(self.tmpdir, 'new.sac')
         shutil.copyfile(testfile, ro_file)
         shutil.copyfile(testfile, rw_file)
-        self.ro_sacobj = sacio.sacfile(ro_file, 'ro')
-        self.rw_sacobj = sacio.sacfile(rw_file, 'rw')
-        self.new_sacobj = sacio.sacfile(new_file, 'new')
+        self.ro_sacobj = sacio.SacFile(ro_file, 'ro')
+        self.rw_sacobj = sacio.SacFile(rw_file, 'rw')
+        self.new_sacobj = sacio.SacFile(new_file, 'new')
 
     def tearDown(self):
         shutil.rmtree(self.tmpdir)
@@ -132,7 +132,7 @@ class sacioTestCase(unittest.TestCase):
         Test changing header values
         """
 
-        # readonly sacfile object should raise an error
+        # readonly SacFile object should raise an error
         with self.assertRaises(IOError):
             self.ro_sacobj.delta = 2
 
@@ -154,7 +154,7 @@ class sacioTestCase(unittest.TestCase):
         """
         newdata = [ 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 ]
 
-        # readonly sacfile object should raise an error
+        # readonly SacFile object should raise an error
         with self.assertRaises(IOError):
             self.ro_sacobj.data = newdata
 


### PR DESCRIPTION
This is for PEP8 naming. With sacfile = SacFile
backwards compatibility is maintained.